### PR TITLE
Gaussian Process Batch MSE. Fixes #7329 and #6483

### DIFF
--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -515,7 +515,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             if eval_MSE:
 
                 y, MSE = np.zeros(n_eval), np.zeros(n_eval)
-                for k in range(max(1, n_eval / batch_size)):
+                for k in range(int(np.ceil(n_eval / float(batch_size)))):
                     batch_from = k * batch_size
                     batch_to = min([(k + 1) * batch_size + 1, n_eval + 1])
                     y[batch_from:batch_to], MSE[batch_from:batch_to] = \


### PR DESCRIPTION
Fixes #7329 and #6483. (Related to Python 3)

I realize this is deprecated, but in case you're still interested in a quick bugfix, my understanding is that this was previously a silent bug even in Python 2.7. In Python 3, this is an error when `n_eval / batch_size` is not an int.

To demonstrate:

```
import numpy as np

def check_mse(n_eval, batch_size):

    y, MSE = np.zeros(n_eval), np.zeros(n_eval)
    for k in range(max(1, n_eval / batch_size)):
        batch_from = k * batch_size
        batch_to = min([(k + 1) * batch_size + 1, n_eval + 1])

        print batch_from, batch_to

def check_mse_fixed(n_eval, batch_size):

    y, MSE = np.zeros(n_eval), np.zeros(n_eval)
    for k in range(int(np.ceil(n_eval / float(batch_size)))):
        batch_from = k * batch_size
        batch_to = min([(k + 1) * batch_size + 1, n_eval + 1])

        print batch_from, batch_to


check_mse(8, 3)
print
check_mse_fixed(8, 3)
```

Python 2.7 output:

```
0 4
3 7

0 4
3 7
6 9
```

Note 8 corresponds to the sample size so the current version (if converted to an int) would miss the last few samples.
